### PR TITLE
Call completion block with errors in PropertiesInteractor and TokenInteractor

### DIFF
--- a/ClangNotifications/Interactors/PropertiesInteractor.swift
+++ b/ClangNotifications/Interactors/PropertiesInteractor.swift
@@ -13,6 +13,10 @@ protocol PropertiesInteractorProtocol: class {
 }
 
 class PropertiesInteractor: PropertiesInteractorProtocol {
+    enum PropertiesInteractorError: Error {
+      case userIdMissing
+  }
+  
   /// Tag to used in debug prints for easy search in Xcode debug console
   private let logTag = "\(PropertiesInteractor.self)"
 
@@ -22,6 +26,7 @@ class PropertiesInteractor: PropertiesInteractorProtocol {
   func updateProperties(data: [String: String], completion: @escaping (Error?) -> Void) {
     guard let userId = storageService.loadUserId() else {
       print("\(self.logTag): UserId is nil!")
+      completion(PropertiesInteractorError.userIdMissing)
       return
     }
 
@@ -29,6 +34,7 @@ class PropertiesInteractor: PropertiesInteractorProtocol {
     serverService.updateProperties(propertiesRequest: propertiesRequestModel) { error in
       guard error == nil else {
         print("\(self.logTag): \(error!)")
+        completion(error!)
         return
       }
 

--- a/ClangNotifications/Interactors/TokenInteractor.swift
+++ b/ClangNotifications/Interactors/TokenInteractor.swift
@@ -13,6 +13,10 @@ protocol TokenInteractorProtocol: class {
 }
 
 class TokenInteractor: TokenInteractorProtocol {
+  enum TokenInteractorError: Error {
+    case userIdMissing
+  }
+  
   /// Tag to used in debug prints for easy search in Xcode debug console
   private let logTag = "\(TokenInteractor.self)"
 
@@ -22,6 +26,7 @@ class TokenInteractor: TokenInteractorProtocol {
   func sendTokenToServer(firebaseToken: String, completion: @escaping (Error?) -> Void) {
     guard let userId = storageService.loadUserId() else {
       print("\(self.logTag): UserId is nil!")
+      completion(TokenInteractorError.userIdMissing)
       return
     }
 


### PR DESCRIPTION
**WHY:**
Previously, PropertiesInteractor and TokenInteractor were just logging errors in the console, therefore giving no information outside the function. 
**WHAT**
Updated methods to call the completion closure with errors if any