### PR TITLE
Add Swift Package Manager manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ Pods/
 # Jazzy docs
 # docs/
 
+# Swift Package Manager
+.build
+.swiftpm
+
 # Other
 .DS_Store
 *.zip

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "evillage-ios",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "ClangNotifications",
+            targets: ["ClangNotifications"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "ClangNotifications",
+            path: "ClangNotifications",
+            exclude: [
+                "ClangNotifications.h",
+                "Info.plist",
+            ]
+        ),
+    ]
+)


### PR DESCRIPTION
This PR adds a `Package.swift` manifest so that the library can be used with the Swift Package Manager.

On the [CocoaPods blog](https://blog.cocoapods.org/) the maintainers write that CocoaPods is currently in maintenance mode, since SPM is the way forward for Apple developers. And they've announced a plan for making it read-only in 2026.